### PR TITLE
Updated gulp-debug to version 2.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "gulp-auto-task": "treshugart/gulp-auto-task#460b425",
     "gulp-babel": "5.2.1",
     "gulp-concat": "2.6.0",
-    "gulp-debug": "2.1.0",
+    "gulp-debug": "2.1.1",
     "gulp-karma": "0.0.4",
     "gulp-rename": "1.2.2",
     "gulp-uglify": "1.4.1",


### PR DESCRIPTION
:rocket:

gulp-debug just published version 2.1.1, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>