### PR TITLE
fixed bug due to typo in remove-child.js

### DIFF
--- a/src/patch/remove-child.js
+++ b/src/patch/remove-child.js
@@ -2,7 +2,7 @@ import nodeMap from '../util/node-map';
 
 export default function (src, tar) {
   const realtar = nodeMap[tar.__id];
-  const realSrc = nodeMap[tar.__id];
+  const realSrc = nodeMap[src.__id];
 
   // We don't do parentNode.removeChild because parentNode may report
   // incorrectly in some prollyfills since it's impossible (?) to spoof.


### PR DESCRIPTION
This bug in remove-child.js was causing the following exception for me:

```
index.js:1050 Uncaught DOMException: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.
    at Object.exports.default (https://localhost:9292/bundle.js:10316:14)
    at patch (https://localhost:9292/bundle.js:10144:30)
    at Array.forEach (<anonymous>)
    at exports.default (https://localhost:9292/bundle.js:10090:17)
    at Object._default [as merge] (https://localhost:9292/bundle.js:10074:24)
    at render (https://localhost:9292/bundle.js:9224:23)
    at ...
```